### PR TITLE
Prefer https over git for pod git URL

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,6 +3,5 @@ platform :ios, "11.2"
 target "Example" do
   use_frameworks!
 
-	#pod "TokenCore", :path => "../"
-  pod "TokenCore", git: "git@github.com:consenlabs/token-core-ios.git"
+  pod "TokenCore", git: "https://github.com/consenlabs/token-core-ios.git"
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
     - GRKOpenSSLFramework
 
 DEPENDENCIES:
-  - "TokenCore (from `git@github.com:consenlabs/token-core-ios.git`)"
+  - TokenCore (from `https://github.com/consenlabs/token-core-ios.git`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -21,12 +21,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   TokenCore:
-    :git: "git@github.com:consenlabs/token-core-ios.git"
+    :git: https://github.com/consenlabs/token-core-ios.git
 
 CHECKOUT OPTIONS:
   TokenCore:
-    :commit: 0bffeb8c393e18761e01e4f73ec4bebb135843be
-    :git: "git@github.com:consenlabs/token-core-ios.git"
+    :commit: bb38707021a78bb34599cbc5c5b1085446c2131b
+    :git: https://github.com/consenlabs/token-core-ios.git
 
 SPEC CHECKSUMS:
   BigInt: a7864bcecd2976bced91963baef90079dbdcca25
@@ -35,6 +35,6 @@ SPEC CHECKSUMS:
   SipHash: fad90a4683e420c52ef28063063dbbce248ea6d4
   TokenCore: c57b3e85b320361eadfc224868c013ef2d875542
 
-PODFILE CHECKSUM: 68079fac95510271214cb66da811d27090f6b664
+PODFILE CHECKSUM: 4c21ebe365fb6455415f6325e9ef333aa3b32c16
 
 COCOAPODS: 1.5.3

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # TokenCore
 TokenCore is a blockchain library. TokenCore provides the relatively consistent API that allows you to manage your wallets and sign transactions in BTC, ETH and EOS chains simultaneously.
-In addition, TokenCore introduces the concept of 'identity', you can use the same mnemonic to manage wallets on the three chains.   
+In addition, TokenCore introduces the concept of 'identity', you can use the same mnemonic to manage wallets on the three chains.
 
 ## Installation
 To install TokenCore, use CocoaPods and add this to your Podfile:
 
 ```
-pod "TokenCore", :git => "git@github.com:consenlabs/token-core-ios.git", :branch => 'master'
+pod "TokenCore", git: "https://github.com/consenlabs/token-core-ios.git", branch: "master"
 ```
 ## Try the API
 ### Create new Identity and derive the eth, btc wallets


### PR DESCRIPTION
A few people are having issue with pod install (#5). Better to use `https` instead of `git` for the git repo URL.