### PR TITLE
fix syntax error / compile error with token-core-ios

### DIFF
--- a/Sources/Encryptor/AES128.swift
+++ b/Sources/Encryptor/AES128.swift
@@ -66,9 +66,9 @@ extension Encryptor {
     private func blockMode(iv: [UInt8]) -> BlockMode {
       switch mode {
       case .cbc:
-        return CBC(iv: iv)
+        return .CBC(iv: iv)
       default:
-        return CTR(iv: iv)
+        return .CTR(iv: iv)
       }
     }
   }


### PR DESCRIPTION
This PR fixes the Issues when compiling token-core-ios:
- Use of unresolved identifier 'CBC'
- Use of unresolved identifier 'CTR'